### PR TITLE
Add mirror pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -126,6 +126,24 @@ steps:
         - VERSION=${DRONE_TAG}
         - COMMIT=${DRONE_COMMIT}
 
+  - name: container-image-mirrored
+    image: plugins/docker
+    settings:
+      registry:
+        from_secret: registry_mirrored
+      username:
+        from_secret: registry_user_mirrored
+      password:
+        from_secret: registry_password_mirrored
+      repo: reg.sighup.io/sighupio/opa-notary-connector
+      dockerfile: build/Dockerfile
+      purge: true
+      force_tag: true
+      auto_tag: true
+      build_args:
+        - VERSION=${DRONE_TAG}
+        - COMMIT=${DRONE_COMMIT}
+
   - name: github-release
     image: plugins/github-release
     settings:


### PR DESCRIPTION
This PR only contains a pipeline to mirror this repository to our private gitlab instance.

The idea is to provide access to future clients to the gitlab repository. But, is just an idea. In any case, i think is a good idea to have it mirrored to our own gitlab instance. (just in case)