### PR TITLE
Add jsonpatch to add a label in case of patch generation

### DIFF
--- a/deployments/helm/opa-notary-connector/opa-config/config.rego
+++ b/deployments/helm/opa-notary-connector/opa-config/config.rego
@@ -68,6 +68,12 @@ patch_logic(k, i, c) = p {
     p := gen_patch(k, i, new_container_image)
 }
 
+prepare_patch(request, index, container_image) = p {
+    c_patch := patch_logic(request.kind.kind, index, container_image)
+    a_patch := annotation_patch(request.object.metadata)
+    p = array.concat(c_patch, a_patch)
+}
+
 deny[msg] {
     is_pod
 
@@ -101,9 +107,7 @@ patches[patch] {
     some j;
     container_image := input.request.object.spec.containers[j].image
 
-    c_patch := patch_logic(input.request.kind.kind, j, container_image)
-    a_patch := annotation_patch(input.request.object.metadata)
-    patch = array.concat(c_patch, a_patch)
+    patch := prepare_patch(input.request, j, container_image)
 }
 
 patches[patch] {
@@ -112,9 +116,7 @@ patches[patch] {
     some j;
     container_image := input.request.object.spec.jobTemplate.spec.template.spec.containers[j].image
 
-    c_patch := patch_logic(input.request.kind.kind, j, container_image)
-    a_patch := annotation_patch(input.request.object.metadata)
-    patch = array.concat(c_patch, a_patch)
+    patch := prepare_patch(input.request, j, container_image)
 }
 
 patches[patch] {
@@ -123,7 +125,5 @@ patches[patch] {
     some j;
     container_image := input.request.object.spec.template.spec.containers[j].image
 
-    c_patch := patch_logic(input.request.kind.kind, j, container_image)
-    a_patch := annotation_patch(input.request.object.metadata)
-    patch = array.concat(c_patch, a_patch)
+    patch := prepare_patch(input.request, j, container_image)
 }

--- a/deployments/helm/opa-notary-connector/opa-config/config_tests.rego
+++ b/deployments/helm/opa-notary-connector/opa-config/config_tests.rego
@@ -92,6 +92,11 @@ test_patch_logic {
     p == [{"op": "replace", "path": "/spec/containers/1/image", "value": "alpine@sha256:randomsha"}]
 }
 
+test_prepare_patch {
+    p := prepare_patch(input.request, "1", "alpine:3.10") with input as mocks.alpine_3_10_pod
+    p == [{"op": "replace", "path": "/spec/containers/1/image", "value": "alpine@sha256:randomsha"}, {"op": "add", "path": "/metadata/annotations", "value": {"opa-notary-connector.sighup.io/processed": "true"}}]
+}
+
 test_deny {
     msg := deny with input as mocks.alpine_3_10_pod
     count(msg) == 0


### PR DESCRIPTION
Hi team!

I've added a label in case of generating a jsonpatch to apply to the container.

jsonpatch `add` operation behaves in idempotent way, meaning that, if label exists, overrides it, if it doesn't, adds it.

```
$ kubectl get pods --show-labels
NAME          READY   STATUS    RESTARTS   AGE     LABELS
debug         1/1     Running   0          5m54s   opa-notary-connector.sighup.io/processed=true,run=debug
debug-multi   2/2     Running   0          2m      opa-notary-connector.sighup.io/processed=true,run=debug-multi
```

It works in my computer :) (and in the pipeline)