### PR TITLE
Add Minio Tenant example

### DIFF
--- a/deployments/helm/opa-notary-connector/opa-config/config_mocks.rego
+++ b/deployments/helm/opa-notary-connector/opa-config/config_mocks.rego
@@ -1431,3 +1431,215 @@ alpine_3_11_deployment = {
     }
   }
 }
+
+alpine_3_11_minio_tenant = {
+  "kind": "AdmissionReview",
+  "apiVersion": "admission.k8s.io/v1beta1",
+  "request": {
+    "uid": "39b56036-a356-4014-9117-cf64aadbb3f4",
+    "kind": {
+      "group": "minio.min.io",
+      "version": "v1",
+      "kind": "Tenant"
+    },
+    "resource": {
+      "group": "minio.min.io",
+      "version": "v1",
+      "resource": "tenants"
+    },
+    "requestKind": {
+      "group": "minio.min.io",
+      "version": "v1",
+      "kind": "Tenant"
+    },
+    "requestResource": {
+      "group": "minio.min.io",
+      "version": "v1",
+      "resource": "tenants"
+    },
+    "name": "debug",
+    "namespace": "default",
+    "operation": "CREATE",
+    "userInfo": {
+      "username": "kubernetes-admin",
+      "groups": [
+        "system:masters",
+        "system:authenticated"
+      ]
+    },
+    "object": {
+      "apiVersion": "minio.min.io/v1",
+      "kind": "Tenant",
+      "metadata": {
+        "name": "minio"
+      },
+      "spec": {
+        "metadata": {
+          "labels": {
+            "app": "minio"
+          },
+          "annotations": {
+            "prometheus.io/path": "/minio/prometheus/metrics",
+            "prometheus.io/port": "9000",
+            "prometheus.io/scrape": "true"
+          }
+        },
+        "image": "alpine:3.11",
+        "serviceName": "minio-internal-service",
+        "zones": [
+          {
+            "servers": 4,
+            "volumesPerServer": 4,
+            "volumeClaimTemplate": {
+              "metadata": {
+                "name": "data"
+              },
+              "spec": {
+                "accessModes": [
+                  "ReadWriteOnce"
+                ],
+                "resources": {
+                  "requests": {
+                    "storage": "1Ti"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "mountPath": "/export",
+        "credsSecret": {
+          "name": "minio-creds-secret"
+        },
+        "podManagementPolicy": "Parallel",
+        "requestAutoCert": false,
+        "certConfig": {
+          "commonName": "",
+          "organizationName": [
+            
+          ],
+          "dnsNames": [
+            
+          ]
+        },
+        "liveness": {
+          "initialDelaySeconds": 10,
+          "periodSeconds": 1,
+          "timeoutSeconds": 1
+        }
+      }
+    },
+    "oldObject": null,
+    "dryRun": false,
+    "options": {
+      "kind": "CreateOptions",
+      "apiVersion": "meta.k8s.io/v1"
+    }
+  }
+}
+
+alpine_3_10_minio_tenant = {
+  "kind": "AdmissionReview",
+  "apiVersion": "admission.k8s.io/v1beta1",
+  "request": {
+    "uid": "39b56036-a356-4014-9117-cf64aadbb3f4",
+    "kind": {
+      "group": "minio.min.io",
+      "version": "v1",
+      "kind": "Tenant"
+    },
+    "resource": {
+      "group": "minio.min.io",
+      "version": "v1",
+      "resource": "tenants"
+    },
+    "requestKind": {
+      "group": "minio.min.io",
+      "version": "v1",
+      "kind": "Tenant"
+    },
+    "requestResource": {
+      "group": "minio.min.io",
+      "version": "v1",
+      "resource": "tenants"
+    },
+    "name": "debug",
+    "namespace": "default",
+    "operation": "CREATE",
+    "userInfo": {
+      "username": "kubernetes-admin",
+      "groups": [
+        "system:masters",
+        "system:authenticated"
+      ]
+    },
+    "object": {
+      "apiVersion": "minio.min.io/v1",
+      "kind": "Tenant",
+      "metadata": {
+        "name": "minio"
+      },
+      "spec": {
+        "metadata": {
+          "labels": {
+            "app": "minio"
+          },
+          "annotations": {
+            "prometheus.io/path": "/minio/prometheus/metrics",
+            "prometheus.io/port": "9000",
+            "prometheus.io/scrape": "true"
+          }
+        },
+        "image": "alpine:3.10",
+        "serviceName": "minio-internal-service",
+        "zones": [
+          {
+            "servers": 4,
+            "volumesPerServer": 4,
+            "volumeClaimTemplate": {
+              "metadata": {
+                "name": "data"
+              },
+              "spec": {
+                "accessModes": [
+                  "ReadWriteOnce"
+                ],
+                "resources": {
+                  "requests": {
+                    "storage": "1Ti"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "mountPath": "/export",
+        "credsSecret": {
+          "name": "minio-creds-secret"
+        },
+        "podManagementPolicy": "Parallel",
+        "requestAutoCert": false,
+        "certConfig": {
+          "commonName": "",
+          "organizationName": [
+            
+          ],
+          "dnsNames": [
+            
+          ]
+        },
+        "liveness": {
+          "initialDelaySeconds": 10,
+          "periodSeconds": 1,
+          "timeoutSeconds": 1
+        }
+      }
+    },
+    "oldObject": null,
+    "dryRun": false,
+    "options": {
+      "kind": "CreateOptions",
+      "apiVersion": "meta.k8s.io/v1"
+    }
+  }
+}

--- a/deployments/helm/opa-notary-connector/opa-config/config_tests.rego
+++ b/deployments/helm/opa-notary-connector/opa-config/config_tests.rego
@@ -166,3 +166,23 @@ test_deny {
     msg := deny with input as mocks.alpine_3_10_and_3_11_deployment
     contains(msg[_], "Container image alpine:3.11 invalid: image not found")
 }
+
+test_deny {
+    msg := deny with input as mocks.alpine_3_10_minio_tenant
+    count(msg) == 0
+}
+
+test_deny {
+    msg := deny with input as mocks.alpine_3_11_minio_tenant
+    contains(msg[_], "Container image alpine:3.11 invalid: image not found")
+}
+
+test_patch {
+    patch := patches with input as mocks.alpine_3_10_minio_tenant
+    count(patch) == 1
+}
+
+test_patch {
+    patch := patches with input as mocks.alpine_3_11_minio_tenant
+    count(patch) == 0
+}

--- a/deployments/helm/opa-notary-connector/opa-config/strict.rego
+++ b/deployments/helm/opa-notary-connector/opa-config/strict.rego
@@ -43,3 +43,12 @@ deny[msg] {
 
     msg := strict_deny_logic(container_image)
 }
+
+deny[msg] {
+    strict_mode
+    input.request.kind.kind == "Tenant"
+
+    container_image := input.request.object.spec.image
+
+    msg := strict_deny_logic(container_image)
+}

--- a/deployments/helm/opa-notary-connector/opa-config/strict_mocks.rego
+++ b/deployments/helm/opa-notary-connector/opa-config/strict_mocks.rego
@@ -663,3 +663,216 @@ alpine_3_10_deployment_incorrect_sha = {
     }
   }
 }
+
+alpine_3_10_minio_tenant_correct_sha = {
+  "kind": "AdmissionReview",
+  "apiVersion": "admission.k8s.io/v1beta1",
+  "request": {
+    "uid": "39b56036-a356-4014-9117-cf64aadbb3f4",
+    "kind": {
+      "group": "minio.min.io",
+      "version": "v1",
+      "kind": "Tenant"
+    },
+    "resource": {
+      "group": "minio.min.io",
+      "version": "v1",
+      "resource": "tenants"
+    },
+    "requestKind": {
+      "group": "minio.min.io",
+      "version": "v1",
+      "kind": "Tenant"
+    },
+    "requestResource": {
+      "group": "minio.min.io",
+      "version": "v1",
+      "resource": "tenants"
+    },
+    "name": "debug",
+    "namespace": "default",
+    "operation": "CREATE",
+    "userInfo": {
+      "username": "kubernetes-admin",
+      "groups": [
+        "system:masters",
+        "system:authenticated"
+      ]
+    },
+    "object": {
+      "apiVersion": "minio.min.io/v1",
+      "kind": "Tenant",
+      "metadata": {
+        "name": "minio"
+      },
+      "spec": {
+        "metadata": {
+          "labels": {
+            "app": "minio"
+          },
+          "annotations": {
+            "prometheus.io/path": "/minio/prometheus/metrics",
+            "prometheus.io/port": "9000",
+            "prometheus.io/scrape": "true"
+          }
+        },
+        "image": "alpine@sha256:randomsha",
+        "serviceName": "minio-internal-service",
+        "zones": [
+          {
+            "servers": 4,
+            "volumesPerServer": 4,
+            "volumeClaimTemplate": {
+              "metadata": {
+                "name": "data"
+              },
+              "spec": {
+                "accessModes": [
+                  "ReadWriteOnce"
+                ],
+                "resources": {
+                  "requests": {
+                    "storage": "1Ti"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "mountPath": "/export",
+        "credsSecret": {
+          "name": "minio-creds-secret"
+        },
+        "podManagementPolicy": "Parallel",
+        "requestAutoCert": false,
+        "certConfig": {
+          "commonName": "",
+          "organizationName": [
+            
+          ],
+          "dnsNames": [
+            
+          ]
+        },
+        "liveness": {
+          "initialDelaySeconds": 10,
+          "periodSeconds": 1,
+          "timeoutSeconds": 1
+        }
+      }
+    },
+    "oldObject": null,
+    "dryRun": false,
+    "options": {
+      "kind": "CreateOptions",
+      "apiVersion": "meta.k8s.io/v1"
+    }
+  }
+}
+
+alpine_3_10_minio_tenant_incorrect_sha = {
+  "kind": "AdmissionReview",
+  "apiVersion": "admission.k8s.io/v1beta1",
+  "request": {
+    "uid": "39b56036-a356-4014-9117-cf64aadbb3f4",
+    "kind": {
+      "group": "minio.min.io",
+      "version": "v1",
+      "kind": "Tenant"
+    },
+    "resource": {
+      "group": "minio.min.io",
+      "version": "v1",
+      "resource": "tenants"
+    },
+    "requestKind": {
+      "group": "minio.min.io",
+      "version": "v1",
+      "kind": "Tenant"
+    },
+    "requestResource": {
+      "group": "minio.min.io",
+      "version": "v1",
+      "resource": "tenants"
+    },
+    "name": "debug",
+    "namespace": "default",
+    "operation": "CREATE",
+    "userInfo": {
+      "username": "kubernetes-admin",
+      "groups": [
+        "system:masters",
+        "system:authenticated"
+      ]
+    },
+    "object": {
+      "apiVersion": "minio.min.io/v1",
+      "kind": "Tenant",
+      "metadata": {
+        "name": "minio"
+      },
+      "spec": {
+        "metadata": {
+          "labels": {
+            "app": "minio"
+          },
+          "annotations": {
+            "prometheus.io/path": "/minio/prometheus/metrics",
+            "prometheus.io/port": "9000",
+            "prometheus.io/scrape": "true"
+          }
+        },
+        "image": "alpine@sha256:malware",
+        "serviceName": "minio-internal-service",
+        "zones": [
+          {
+            "servers": 4,
+            "volumesPerServer": 4,
+            "volumeClaimTemplate": {
+              "metadata": {
+                "name": "data"
+              },
+              "spec": {
+                "accessModes": [
+                  "ReadWriteOnce"
+                ],
+                "resources": {
+                  "requests": {
+                    "storage": "1Ti"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "mountPath": "/export",
+        "credsSecret": {
+          "name": "minio-creds-secret"
+        },
+        "podManagementPolicy": "Parallel",
+        "requestAutoCert": false,
+        "certConfig": {
+          "commonName": "",
+          "organizationName": [
+            
+          ],
+          "dnsNames": [
+            
+          ]
+        },
+        "liveness": {
+          "initialDelaySeconds": 10,
+          "periodSeconds": 1,
+          "timeoutSeconds": 1
+        }
+      }
+    },
+    "oldObject": null,
+    "dryRun": false,
+    "options": {
+      "kind": "CreateOptions",
+      "apiVersion": "meta.k8s.io/v1"
+    }
+  }
+}
+

--- a/deployments/helm/opa-notary-connector/opa-config/strict_tests.rego
+++ b/deployments/helm/opa-notary-connector/opa-config/strict_tests.rego
@@ -86,3 +86,23 @@ test_deny {
     msg := deny with input as mocks.alpine_3_10_deployment_incorrect_sha with data.webhook["opa-notary-connector-mode"]["mode.json"].strict as true
     count(msg) == 1
 }
+
+test_deny {
+    msg := deny with input as mocks.alpine_3_10_minio_tenant_correct_sha
+    count(msg) == 0
+}
+
+test_deny {
+    msg := deny with input as mocks.alpine_3_10_minio_tenant_incorrect_sha
+    count(msg) == 0
+}
+
+test_deny {
+    msg := deny with input as mocks.alpine_3_10_minio_tenant_correct_sha with data.webhook["opa-notary-connector-mode"]["mode.json"].strict as true
+    count(msg) == 0
+}
+
+test_deny {
+    msg := deny with input as mocks.alpine_3_10_minio_tenant_incorrect_sha with data.webhook["opa-notary-connector-mode"]["mode.json"].strict as true
+    count(msg) == 1
+}


### PR DESCRIPTION
Hi team! 

The trello card https://trello.com/c/qhrh753G mention to document how to extend OPA Notary Connector to allow non-primitives Kubernetes resources (CRDs) to being validated/patched with OPA Notary Connector.

I was writing docs about how to do it and i wrote a couple of tests to ensure it is possible. Here is the result.

```rego
deny[msg] {
    input.request.kind.kind == "Tenant"
    container_image := input.request.object.spec.image
    msg := deny_logic(container_image)
}

deny[msg] {
    strict_mode
    input.request.kind.kind == "Tenant"
    container_image := input.request.object.spec.image
    msg := strict_deny_logic(container_image)
} 

patches[patch] {
    input.request.kind.kind == "Tenant"
    container_image := input.request.object.spec.image
    response := req_opa_notary_connector(container_image)
    response.status_code == 200
    new_container_image := response.body.image
    i_patch := [{"op": "replace", "path": "/spec/image", "value": new_container_image}]
    a_patch := annotation_patch(input.request.object.metadata)
    patch := array.concat(i_patch, a_patch)
}
```

This this piece of code Minio Tenants are validated as Kubernetes Primitives (Pods, deployments...) This example is already available in the onboarding document im currently writing.

Thanks!