### PR TITLE
added denied variable to make tests leaner

### DIFF
--- a/deployments/helm/opa-notary-connector/opa-config/config.rego
+++ b/deployments/helm/opa-notary-connector/opa-config/config.rego
@@ -58,6 +58,10 @@ deny[msg] {
   msg := sprintf("Container image %v invalid: %v", [opa_notary_connector_responses[i].image, error_message])
 }
 
+denied = true {
+  count(deny)>0
+}
+
 
 patches[patch] {
   opa_notary_connector_responses[i].index
@@ -70,9 +74,13 @@ patches[patch] {
 
 patches[patch]{
   input.request.object.metadata.annotations
-patch := {"op": "add", "path": "/metadata/annotations/opa-notary-connector.sighup.io~1processed", "value": "true"}
+  patch := {"op": "add", "path": "/metadata/annotations/opa-notary-connector.sighup.io~1processed", "value": "true"}
 } {
-    patch := {"op": "add", "path": "/metadata/annotations", "value": {"opa-notary-connector.sighup.io/processed": "true"}}
+  patch := {"op": "add", "path": "/metadata/annotations", "value": {"opa-notary-connector.sighup.io/processed": "true"}}
+}
+
+patched = true {
+  count(patches) > 1
 }
 
 

--- a/deployments/helm/opa-notary-connector/opa-config/config_tests.rego
+++ b/deployments/helm/opa-notary-connector/opa-config/config_tests.rego
@@ -3,73 +3,80 @@ package kubernetes.admission
 import data.kubernetes.admission.mocks
 
 
-test_images {
+test_not_denied {
+  not denied with deny as set()
+}
+
+test_denied {
+  denied with deny as {"test"}
+}
+
+test_image_pod {
     img := images with input as mocks.alpine_3_11_pod
     count(img) == 1
 }
 
-test_images {
+test_image_pod {
+    img := images with input as mocks.alpine_3_10_pod
+    count(img) == 1
+}
+
+test_different_images_pod {
     img := images with input as mocks.alpine_3_11_and_3_10_pod
     count(img) == 2
 }
 
-test_images {
+test_same_images_pod {
     img := images with input as mocks.alpine_3_10_and_3_10_pod
     count(img) == 2
 }
 
 test_not_deny_pod {
-  msg := deny with input as mocks.alpine_3_10_pod
-  count(msg) == 0
+  not denied with input as mocks.alpine_3_10_pod
 }
 
 test_not_deny_pod {
-  msg := deny with input as mocks.alpine_3_10_and_3_10_pod
-  count(msg) == 0
+  not denied with input as mocks.alpine_3_10_and_3_10_pod
 }
 
 test_deny_pod {
-  deny with input as mocks.alpine_3_11_pod
+  denied with input as mocks.alpine_3_11_pod
 }
 
 test_deny_pod {
-  deny with input as mocks.alpine_3_11_and_3_10_pod
+  denied with input as mocks.alpine_3_11_and_3_10_pod
 }
 
 
 test_deny_deployment {
-    deny with input as mocks.alpine_3_11_deployment
+    denied with input as mocks.alpine_3_11_deployment
 }
 
 test_deny_deployment {
-    deny with input as mocks.alpine_3_10_and_3_11_deployment
+    denied with input as mocks.alpine_3_10_and_3_11_deployment
 }
 
 test_deny_cronjob {
-  deny with input as mocks.alpine_3_11_cronjob
+  denied with input as mocks.alpine_3_11_cronjob
 }
 
 test_deny_cronjob {
-  deny with input as mocks.alpine_3_10_and_3_11_cronjob
+  denied with input as mocks.alpine_3_10_and_3_11_cronjob
 }
 
 test_not_deny_cronjob {
-  msg := deny with input as mocks.alpine_3_10_cronjob
-  count(msg) == 0
+  not denied with input as mocks.alpine_3_10_cronjob
 }
 
 test_not_deny_cronjob {
-  msg := deny with input as mocks.alpine_3_10_and_3_10_cronjob
-  count(msg) == 0
+  not denied with input as mocks.alpine_3_10_and_3_10_cronjob
 }
 
 test_not_deny_deployment {
-  msg := deny with input as mocks.alpine_3_10_deployment
-  count(msg) == 0
+  not denied with input as mocks.alpine_3_10_deployment
 }
 
 test_not_deny_deployment {
-  msg := deny with input as mocks.alpine_3_10_and_3_10_deployment
-  count(msg) == 0
+  not denied with input as mocks.alpine_3_10_and_3_10_deployment
 }
 

--- a/deployments/helm/opa-notary-connector/opa-config/strict_tests.rego
+++ b/deployments/helm/opa-notary-connector/opa-config/strict_tests.rego
@@ -11,60 +11,51 @@ test_strict_mode {
 }
 
 test_deny_pod_strict {
-  deny with input as mocks.alpine_3_10_pod_incorrect_sha with data.webhook["opa-notary-connector-mode"]["mode.json"].strict as true
+  denied with input as mocks.alpine_3_10_pod_incorrect_sha with data.webhook["opa-notary-connector-mode"]["mode.json"].strict as true
 }
 
 test_deny_cronjob_strict {
-  deny with input as mocks.alpine_3_10_cronjob_incorrect_sha with data.webhook["opa-notary-connector-mode"]["mode.json"].strict as true
+  denied with input as mocks.alpine_3_10_cronjob_incorrect_sha with data.webhook["opa-notary-connector-mode"]["mode.json"].strict as true
 }
 
 test_deny_deployment_strict {
-  deny with input as mocks.alpine_3_10_deployment_incorrect_sha with data.webhook["opa-notary-connector-mode"]["mode.json"].strict as true
+  denied with input as mocks.alpine_3_10_deployment_incorrect_sha with data.webhook["opa-notary-connector-mode"]["mode.json"].strict as true
 }
 
 test_not_deny_pod_strict {
-  msg := deny with input as mocks.alpine_3_10_pod_correct_sha with data.webhook["opa-notary-connector-mode"]["mode.json"].strict as true
-  count(msg) == 0
+  not denied with input as mocks.alpine_3_10_pod_correct_sha with data.webhook["opa-notary-connector-mode"]["mode.json"].strict as true
 }
 
 test_not_deny_deployment_strict {
-  msg := deny with input as mocks.alpine_3_10_deployment_correct_sha with data.webhook["opa-notary-connector-mode"]["mode.json"].strict as true
-  count(msg) == 0
+  not denied with input as mocks.alpine_3_10_deployment_correct_sha with data.webhook["opa-notary-connector-mode"]["mode.json"].strict as true
 }
 
 test_not_deny_cronjob_strict {
-  msg := deny with input as mocks.alpine_3_10_cronjob_correct_sha with data.webhook["opa-notary-connector-mode"]["mode.json"].strict as true
-  count(msg) == 0
+  not denied with input as mocks.alpine_3_10_cronjob_correct_sha with data.webhook["opa-notary-connector-mode"]["mode.json"].strict as true
 }
 
 test_not_deny_cronjob {
-  msg := deny with input as mocks.alpine_3_10_cronjob_correct_sha
-  count(msg) == 0
+  not denied with input as mocks.alpine_3_10_cronjob_correct_sha
 }
 
 test_not_deny_cronjob {
-  msg := deny with input as mocks.alpine_3_10_cronjob_incorrect_sha
-  count(msg) == 0
+  not denied with input as mocks.alpine_3_10_cronjob_incorrect_sha
 }
 
 test_not_deny_deployment {
-  msg := deny with input as mocks.alpine_3_10_deployment_correct_sha
-  count(msg) == 0
+  not denied with input as mocks.alpine_3_10_deployment_correct_sha
 }
 
 test_not_deny_deployment {
-  msg := deny with input as mocks.alpine_3_10_deployment_incorrect_sha
-  count(msg) == 0
+  not denied with input as mocks.alpine_3_10_deployment_incorrect_sha
 }
 
 
 test_not_deny_pod {
-  msg := deny with input as mocks.alpine_3_10_pod_correct_sha
-  count(msg) == 0
+  not denied with input as mocks.alpine_3_10_pod_correct_sha
 }
 
 test_not_deny_pod {
-  msg := deny with input as mocks.alpine_3_10_pod_incorrect_sha
-  count(msg) == 0
+  not denied with input as mocks.alpine_3_10_pod_incorrect_sha
 }
 


### PR DESCRIPTION
Improved tests readability by adding a `denied` variable which is equal to `count(deny) > 0`, given that the empty set boolean value in rego is not false this allows to avoid checking every time the number of messages in the deny set.